### PR TITLE
Workdlow support

### DIFF
--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -1,0 +1,36 @@
+name: Build debian
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+jobs:
+  build-debian:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2.3.4
+
+      - name: Update submodules
+        run: git submodule update --init --recursive
+
+      - name: Create a build directory
+        run: mkdir build
+
+      - name: Configure CMake
+        working-directory: build
+        run: cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+
+      - name: Build the project
+        working-directory: build
+        run: make -j8
+
+      - name: Build Debian package
+        working-directory: build
+        run: cpack
+
+      - name: Save result
+        uses: actions/upload-artifact@v2.2.3
+        with:
+          name: package
+          path: build/*.deb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ set(CPACK_DEBIAN_PACKAGE_NAME "libsomething-dev")
 set(CPACK_DEBIAN_PACKAGE_VERSION 1.0.0)
 set(CPACK_DEBIAN_PACKAGE_RELEASE 1)
 
+# Uncomment this to use timestamp for the Debian release number
+# string(TIMESTAMP NOW "%s")
+# set(CPACK_DEBIAN_PACKAGE_RELEASE ${NOW})
+
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "some short description")
 
 set(CPACK_PACKAGE_DESCRIPTION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 
 project(libsomething-dev)
 
-add_subdirectory("folder-name")
+# Uncomment this to include a git submodule directory to this package
+# add_subdirectory("folder-name")
 
 set(CPACK_GENERATOR "DEB")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
@@ -23,10 +24,10 @@ set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://something.org/")
 
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libfoo, libgoo (>= 1.2)")
 
-# Uncomment if this package has conflict with other packages
+# Uncomment this if this package has conflict with other packages
 # set(CPACK_DEBIAN_PACKAGE_CONFLICTS "libpresomething-dev")
 
-# Uncomment if this package is replacing other packages
+# Uncomment this if this package is replacing other packages
 # set(CPACK_DEBIAN_PACKAGE_REPLACES "libpresomething-dev")
 
 include(CPack)


### PR DESCRIPTION
- Add build Debian workflow.
- Uncomment `add_subdirectory()` in `CMakeLists.txt`.
- Add support to use timestamp for the Debian release number.