### PR TITLE
Add shlibs support

### DIFF
--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -25,11 +25,11 @@ jobs:
         working-directory: build
         run: make -j8
 
-      - name: Build Debian package
+      - name: Build Debian packages
         working-directory: build
-        run: cpack
+        run: make package
 
-      - name: Save result
+      - name: Save results
         uses: actions/upload-artifact@v2.2.3
         with:
           name: package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,22 @@ cmake_minimum_required(VERSION 3.10)
 
 project(libsomething-dev)
 
-# Uncomment this to include a git submodule directory to this package
+# Uncomment this line to include a git submodule directory to this package
 # add_subdirectory("folder-name")
 
 set(CPACK_GENERATOR "DEB")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+
+# Uncomment this lines to enable shlibs for this project
+# set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+# set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS ON)
 
 set(CPACK_DEBIAN_PACKAGE_NAME "libsomething-dev")
 
 set(CPACK_DEBIAN_PACKAGE_VERSION 1.0.0)
 set(CPACK_DEBIAN_PACKAGE_RELEASE 1)
 
-# Uncomment this to use timestamp for the Debian release number
+# Uncomment this lines to use timestamp for the Debian release number
 # string(TIMESTAMP NOW "%s")
 # set(CPACK_DEBIAN_PACKAGE_RELEASE ${NOW})
 
@@ -28,10 +32,10 @@ set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://something.org/")
 
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libfoo, libgoo (>= 1.2)")
 
-# Uncomment this if this package has conflict with other packages
+# Uncomment this line if this package has conflict with other packages
 # set(CPACK_DEBIAN_PACKAGE_CONFLICTS "libpresomething-dev")
 
-# Uncomment this if this package is replacing other packages
+# Uncomment this line if this package is replacing other packages
 # set(CPACK_DEBIAN_PACKAGE_REPLACES "libpresomething-dev")
 
 include(CPack)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project works by including a third-party source code as a [Git submodule](h
   $ mkdir build
   $ cd build
   ```
-- Configure the CMake with the following options.
+- Configure CMake with the following options.
   ```bash
   $ cmake -DCMAKE_INSTALL_PREFIX=/usr ..
   ```
@@ -40,9 +40,9 @@ This project works by including a third-party source code as a [Git submodule](h
   $ make
   ```
   > Optionally, you could speed up the build process by specifying the parallel job using `-j` option, see [this](https://www.gnu.org/software/make/manual/html_node/Parallel.html).
-- Create the Debian package using CPack.
+- Build Debian packages.
   ```bash
-  $ cpack
+  $ make package
   ```
 
 ## Usage Examples
@@ -53,4 +53,4 @@ This list contains repositories that use the template from this repository.
 
 ## License
 
-This project is maintained by [Alfi Maulana](https://threeal.github.io/) and licensed under the [MIT LICENSE](./LICENSE)
+This project is licensed under the [MIT License](./LICENSE)


### PR DESCRIPTION
- Replace the `cpack` command with a `make package` command.
- Add shlibs support as commented lines in the `CMakeLists.txt`.